### PR TITLE
Add user preferences management feature

### DIFF
--- a/adapter/adapter-rest/src/main/java/io/github/hexagonal/weather/adapter/rest/InMemoryUserPreferencesRepository.java
+++ b/adapter/adapter-rest/src/main/java/io/github/hexagonal/weather/adapter/rest/InMemoryUserPreferencesRepository.java
@@ -1,0 +1,29 @@
+package io.github.hexagonal.weather.adapter.rest;
+
+import io.github.hexagonal.weather.application.port.out.UserPreferencesRepository;
+import io.github.hexagonal.weather.model.UserPreferences;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory implementation of user preferences repository.
+ */
+@ApplicationScoped
+public class InMemoryUserPreferencesRepository implements UserPreferencesRepository {
+
+    private final Map<String, UserPreferences> storage = new ConcurrentHashMap<>();
+
+    @Override
+    public UserPreferences save(UserPreferences preferences) {
+        storage.put(preferences.userId(), preferences);
+        return preferences;
+    }
+
+    @Override
+    public Optional<UserPreferences> findByUserId(String userId) {
+        return Optional.ofNullable(storage.get(userId));
+    }
+}

--- a/adapter/adapter-rest/src/main/java/io/github/hexagonal/weather/adapter/rest/UserPreferencesController.java
+++ b/adapter/adapter-rest/src/main/java/io/github/hexagonal/weather/adapter/rest/UserPreferencesController.java
@@ -1,0 +1,37 @@
+package io.github.hexagonal.weather.adapter.rest;
+
+import io.github.hexagonal.weather.application.port.in.ManageUserPreferencesUseCase;
+import io.github.hexagonal.weather.model.UserPreferences;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * REST endpoint for managing user weather preferences.
+ */
+@Path("/preferences")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class UserPreferencesController {
+
+    private final ManageUserPreferencesUseCase manageUserPreferencesUseCase;
+
+    @Inject
+    public UserPreferencesController(ManageUserPreferencesUseCase manageUserPreferencesUseCase) {
+        this.manageUserPreferencesUseCase = manageUserPreferencesUseCase;
+    }
+
+    @POST
+    public Response savePreferences(UserPreferences preferences) {
+        UserPreferences saved = manageUserPreferencesUseCase.savePreferences(preferences);
+        return Response.ok(saved).build();
+    }
+
+    @GET
+    @Path("/{userId}")
+    public Response getPreferences(@PathParam("userId") String userId) {
+        UserPreferences preferences = manageUserPreferencesUseCase.getPreferences(userId);
+        return Response.ok(preferences).build();
+    }
+}

--- a/application/src/main/java/io/github/hexagonal/weather/application/port/in/ManageUserPreferencesUseCase.java
+++ b/application/src/main/java/io/github/hexagonal/weather/application/port/in/ManageUserPreferencesUseCase.java
@@ -1,0 +1,25 @@
+package io.github.hexagonal.weather.application.port.in;
+
+import io.github.hexagonal.weather.model.UserPreferences;
+
+/**
+ * Use case for managing user preferences.
+ */
+public interface ManageUserPreferencesUseCase {
+
+    /**
+     * Saves or updates user preferences.
+     *
+     * @param preferences The user preferences to save
+     * @return The saved preferences
+     */
+    UserPreferences savePreferences(UserPreferences preferences);
+
+    /**
+     * Retrieves user preferences by user ID.
+     *
+     * @param userId The user identifier
+     * @return User preferences if found
+     */
+    UserPreferences getPreferences(String userId);
+}

--- a/application/src/main/java/io/github/hexagonal/weather/application/port/out/UserPreferencesRepository.java
+++ b/application/src/main/java/io/github/hexagonal/weather/application/port/out/UserPreferencesRepository.java
@@ -1,0 +1,27 @@
+package io.github.hexagonal.weather.application.port.out;
+
+import io.github.hexagonal.weather.model.UserPreferences;
+
+import java.util.Optional;
+
+/**
+ * Repository interface for user preferences persistence.
+ */
+public interface UserPreferencesRepository {
+
+    /**
+     * Saves user preferences.
+     *
+     * @param preferences The preferences to save
+     * @return The saved preferences
+     */
+    UserPreferences save(UserPreferences preferences);
+
+    /**
+     * Finds user preferences by user ID.
+     *
+     * @param userId The user identifier
+     * @return Optional containing preferences if found
+     */
+    Optional<UserPreferences> findByUserId(String userId);
+}

--- a/application/src/main/java/io/github/hexagonal/weather/application/service/UserPreferencesService.java
+++ b/application/src/main/java/io/github/hexagonal/weather/application/service/UserPreferencesService.java
@@ -1,0 +1,32 @@
+package io.github.hexagonal.weather.application.service;
+
+import io.github.hexagonal.weather.application.port.in.ManageUserPreferencesUseCase;
+import io.github.hexagonal.weather.application.port.out.UserPreferencesRepository;
+import io.github.hexagonal.weather.model.UserPreferences;
+import lombok.extern.jbosslog.JBossLog;
+
+/**
+ * Service for managing user weather preferences.
+ */
+@JBossLog
+public class UserPreferencesService implements ManageUserPreferencesUseCase {
+
+    private final UserPreferencesRepository repository;
+
+    public UserPreferencesService(UserPreferencesRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public UserPreferences savePreferences(UserPreferences preferences) {
+        log.infof("Saving preferences for user: %s", preferences.userId());
+        return repository.save(preferences);
+    }
+
+    @Override
+    public UserPreferences getPreferences(String userId) {
+        log.infof("Retrieving preferences for user: %s", userId);
+        return repository.findByUserId(userId)
+            .orElseThrow(() -> new IllegalArgumentException("User preferences not found for: " + userId));
+    }
+}

--- a/bootstrap/src/main/java/io/github/hexagonal/weather/bootstrap/config/ApplicationConfig.java
+++ b/bootstrap/src/main/java/io/github/hexagonal/weather/bootstrap/config/ApplicationConfig.java
@@ -1,7 +1,10 @@
 package io.github.hexagonal.weather.bootstrap.config;
 
 import io.github.hexagonal.weather.application.port.in.GetWeatherUseCase;
+import io.github.hexagonal.weather.application.port.in.ManageUserPreferencesUseCase;
+import io.github.hexagonal.weather.application.port.out.UserPreferencesRepository;
 import io.github.hexagonal.weather.application.port.out.WeatherProvider;
+import io.github.hexagonal.weather.application.service.UserPreferencesService;
 import io.github.hexagonal.weather.application.service.WeatherService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
@@ -24,5 +27,14 @@ public class ApplicationConfig {
     @ApplicationScoped
     public GetWeatherUseCase getWeatherUseCase(WeatherProvider weatherProvider) {
         return new WeatherService(weatherProvider);
+    }
+
+    /**
+     * Produces the ManageUserPreferencesUseCase bean.
+     */
+    @Produces
+    @ApplicationScoped
+    public ManageUserPreferencesUseCase manageUserPreferencesUseCase(UserPreferencesRepository repository) {
+        return new UserPreferencesService(repository);
     }
 }

--- a/model/src/main/java/io/github/hexagonal/weather/model/UserPreferences.java
+++ b/model/src/main/java/io/github/hexagonal/weather/model/UserPreferences.java
@@ -1,0 +1,24 @@
+package io.github.hexagonal.weather.model;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Domain model representing user weather preferences.
+ *
+ * @param userId              Unique identifier for the user
+ * @param temperatureUnit     Preferred temperature unit (Celsius/Fahrenheit)
+ * @param defaultLocation     User's default location for weather queries
+ * @param notificationsEnabled Whether user wants weather notifications
+ */
+public record UserPreferences(
+    @NotBlank String userId,
+    @NotNull TemperatureUnit temperatureUnit,
+    Location defaultLocation,
+    boolean notificationsEnabled
+) {
+    public enum TemperatureUnit {
+        CELSIUS,
+        FAHRENHEIT
+    }
+}


### PR DESCRIPTION
Implement user preferences functionality to allow users to customize their weather experience with the following capabilities:

- Save and retrieve user weather preferences
- Configure temperature unit preference (Celsius/Fahrenheit)
- Set default location for weather queries
- Enable/disable weather notifications

Technical implementation:
- New UserPreferences domain model
- ManageUserPreferencesUseCase port
- UserPreferencesService application service
- REST endpoints at /preferences
- In-memory repository for preference storage

+semver: minor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a User Preferences API to create/update and retrieve weather preferences by user ID.
  * Supports setting preferred temperature unit (Celsius or Fahrenheit), default location, and enabling/disabling notifications.
  * Endpoints: POST /preferences (JSON payload) and GET /preferences/{userId} (JSON response).
  * Includes validation for required fields (userId and temperature unit) to ensure consistent input.
  * Enables personalized forecasts and notifications based on saved preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->