### PR TITLE
Add user preferences management feature

### DIFF
--- a/adapter/adapter-preferences/pom.xml
+++ b/adapter/adapter-preferences/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.github.hexagonal</groupId>
+        <artifactId>adapter</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>adapter-preferences</artifactId>
+    <name>Weather Service - Preferences Adapter</name>
+    <description>In-memory user preferences repository</description>
+
+    <dependencies>
+        <!-- Application layer (ports) -->
+        <dependency>
+            <groupId>io.github.hexagonal</groupId>
+            <artifactId>application</artifactId>
+        </dependency>
+
+        <!-- Model layer (domain) -->
+        <dependency>
+            <groupId>io.github.hexagonal</groupId>
+            <artifactId>model</artifactId>
+        </dependency>
+
+        <!-- CDI for dependency injection -->
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/adapter/adapter-preferences/src/main/java/io/github/hexagonal/weather/adapter/preferences/InMemoryUserPreferencesRepository.java
+++ b/adapter/adapter-preferences/src/main/java/io/github/hexagonal/weather/adapter/preferences/InMemoryUserPreferencesRepository.java
@@ -1,0 +1,29 @@
+package io.github.hexagonal.weather.adapter.preferences;
+
+import io.github.hexagonal.weather.application.port.out.UserPreferencesRepository;
+import io.github.hexagonal.weather.model.UserPreferences;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory implementation of user preferences repository.
+ */
+@ApplicationScoped
+public class InMemoryUserPreferencesRepository implements UserPreferencesRepository {
+
+    private final Map<String, UserPreferences> storage = new ConcurrentHashMap<>();
+
+    @Override
+    public UserPreferences save(UserPreferences preferences) {
+        storage.put(preferences.userId(), preferences);
+        return preferences;
+    }
+
+    @Override
+    public Optional<UserPreferences> findByUserId(String userId) {
+        return Optional.ofNullable(storage.get(userId));
+    }
+}

--- a/adapter/adapter-rest/src/main/java/io/github/hexagonal/weather/adapter/rest/UserPreferencesController.java
+++ b/adapter/adapter-rest/src/main/java/io/github/hexagonal/weather/adapter/rest/UserPreferencesController.java
@@ -1,0 +1,40 @@
+package io.github.hexagonal.weather.adapter.rest;
+
+import io.github.hexagonal.weather.adapter.rest.dto.UserPreferencesRequest;
+import io.github.hexagonal.weather.adapter.rest.dto.UserPreferencesResponse;
+import io.github.hexagonal.weather.adapter.rest.mapper.UserPreferencesRestMapper;
+import io.github.hexagonal.weather.application.port.in.ManageUserPreferencesUseCase;
+import io.github.hexagonal.weather.model.UserPreferences;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+
+/**
+ * REST controller for user preferences management.
+ */
+@Path("/preferences")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class UserPreferencesController {
+
+    private final ManageUserPreferencesUseCase useCase;
+    private final UserPreferencesRestMapper mapper;
+
+    public UserPreferencesController(ManageUserPreferencesUseCase useCase, UserPreferencesRestMapper mapper) {
+        this.useCase = useCase;
+        this.mapper = mapper;
+    }
+
+    @POST
+    public UserPreferencesResponse savePreferences(UserPreferencesRequest request) {
+        UserPreferences preferences = mapper.toDomain(request);
+        UserPreferences saved = useCase.savePreferences(preferences);
+        return mapper.toResponse(saved);
+    }
+
+    @GET
+    @Path("/{userId}")
+    public UserPreferencesResponse getPreferences(@PathParam("userId") String userId) {
+        UserPreferences preferences = useCase.getPreferences(userId);
+        return mapper.toResponse(preferences);
+    }
+}

--- a/adapter/adapter-rest/src/main/java/io/github/hexagonal/weather/adapter/rest/dto/LocationDto.java
+++ b/adapter/adapter-rest/src/main/java/io/github/hexagonal/weather/adapter/rest/dto/LocationDto.java
@@ -1,0 +1,10 @@
+package io.github.hexagonal.weather.adapter.rest.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record LocationDto(
+    double latitude,
+    double longitude,
+    @JsonProperty("city_name") String cityName
+) {
+}

--- a/adapter/adapter-rest/src/main/java/io/github/hexagonal/weather/adapter/rest/dto/UserPreferencesRequest.java
+++ b/adapter/adapter-rest/src/main/java/io/github/hexagonal/weather/adapter/rest/dto/UserPreferencesRequest.java
@@ -1,0 +1,11 @@
+package io.github.hexagonal.weather.adapter.rest.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record UserPreferencesRequest(
+    @JsonProperty("user_id") String userId,
+    @JsonProperty("temperature_unit") String temperatureUnit,
+    @JsonProperty("default_location") LocationDto defaultLocation,
+    @JsonProperty("notifications_enabled") boolean notificationsEnabled
+) {
+}

--- a/adapter/adapter-rest/src/main/java/io/github/hexagonal/weather/adapter/rest/dto/UserPreferencesResponse.java
+++ b/adapter/adapter-rest/src/main/java/io/github/hexagonal/weather/adapter/rest/dto/UserPreferencesResponse.java
@@ -1,0 +1,11 @@
+package io.github.hexagonal.weather.adapter.rest.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record UserPreferencesResponse(
+    @JsonProperty("user_id") String userId,
+    @JsonProperty("temperature_unit") String temperatureUnit,
+    @JsonProperty("default_location") LocationDto defaultLocation,
+    @JsonProperty("notifications_enabled") boolean notificationsEnabled
+) {
+}

--- a/adapter/adapter-rest/src/main/java/io/github/hexagonal/weather/adapter/rest/mapper/UserPreferencesRestMapper.java
+++ b/adapter/adapter-rest/src/main/java/io/github/hexagonal/weather/adapter/rest/mapper/UserPreferencesRestMapper.java
@@ -1,0 +1,50 @@
+package io.github.hexagonal.weather.adapter.rest.mapper;
+
+import io.github.hexagonal.weather.adapter.rest.dto.LocationDto;
+import io.github.hexagonal.weather.adapter.rest.dto.UserPreferencesRequest;
+import io.github.hexagonal.weather.adapter.rest.dto.UserPreferencesResponse;
+import io.github.hexagonal.weather.model.Location;
+import io.github.hexagonal.weather.model.TemperatureUnit;
+import io.github.hexagonal.weather.model.UserPreferences;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Mapper for user preferences REST DTOs.
+ */
+@ApplicationScoped
+public class UserPreferencesRestMapper {
+
+    public UserPreferences toDomain(UserPreferencesRequest request) {
+        Location location = request.defaultLocation() != null
+            ? new Location(
+                request.defaultLocation().latitude(),
+                request.defaultLocation().longitude(),
+                request.defaultLocation().cityName())
+            : null;
+
+        TemperatureUnit unit = TemperatureUnit.valueOf(request.temperatureUnit().toUpperCase());
+
+        return new UserPreferences(
+            request.userId(),
+            unit,
+            location,
+            request.notificationsEnabled()
+        );
+    }
+
+    public UserPreferencesResponse toResponse(UserPreferences preferences) {
+        LocationDto locationDto = preferences.defaultLocation() != null
+            ? new LocationDto(
+                preferences.defaultLocation().latitude(),
+                preferences.defaultLocation().longitude(),
+                preferences.defaultLocation().cityName())
+            : null;
+
+        return new UserPreferencesResponse(
+            preferences.userId(),
+            preferences.temperatureUnit().name(),
+            locationDto,
+            preferences.notificationsEnabled()
+        );
+    }
+}

--- a/adapter/pom.xml
+++ b/adapter/pom.xml
@@ -18,5 +18,6 @@
     <modules>
         <module>adapter-rest</module>
         <module>adapter-openmeteo</module>
+        <module>adapter-preferences</module>
     </modules>
 </project>

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -34,6 +34,12 @@
             <artifactId>jboss-logging</artifactId>
         </dependency>
 
+        <!-- CDI for dependency injection -->
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+
         <!-- Testing -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/application/src/main/java/io/github/hexagonal/weather/application/port/in/ManageUserPreferencesUseCase.java
+++ b/application/src/main/java/io/github/hexagonal/weather/application/port/in/ManageUserPreferencesUseCase.java
@@ -1,0 +1,25 @@
+package io.github.hexagonal.weather.application.port.in;
+
+import io.github.hexagonal.weather.model.UserPreferences;
+
+/**
+ * Use case for managing user preferences.
+ */
+public interface ManageUserPreferencesUseCase {
+
+    /**
+     * Saves or updates user preferences.
+     *
+     * @param preferences User preferences to save
+     * @return Saved preferences
+     */
+    UserPreferences savePreferences(UserPreferences preferences);
+
+    /**
+     * Retrieves user preferences by user ID.
+     *
+     * @param userId User identifier
+     * @return User preferences or default if not found
+     */
+    UserPreferences getPreferences(String userId);
+}

--- a/application/src/main/java/io/github/hexagonal/weather/application/port/out/UserPreferencesRepository.java
+++ b/application/src/main/java/io/github/hexagonal/weather/application/port/out/UserPreferencesRepository.java
@@ -1,0 +1,27 @@
+package io.github.hexagonal.weather.application.port.out;
+
+import io.github.hexagonal.weather.model.UserPreferences;
+
+import java.util.Optional;
+
+/**
+ * Repository port for user preferences persistence.
+ */
+public interface UserPreferencesRepository {
+
+    /**
+     * Saves user preferences.
+     *
+     * @param preferences Preferences to save
+     * @return Saved preferences
+     */
+    UserPreferences save(UserPreferences preferences);
+
+    /**
+     * Finds user preferences by user ID.
+     *
+     * @param userId User identifier
+     * @return Optional containing preferences if found
+     */
+    Optional<UserPreferences> findByUserId(String userId);
+}

--- a/application/src/main/java/io/github/hexagonal/weather/application/service/UserPreferencesService.java
+++ b/application/src/main/java/io/github/hexagonal/weather/application/service/UserPreferencesService.java
@@ -1,0 +1,30 @@
+package io.github.hexagonal.weather.application.service;
+
+import io.github.hexagonal.weather.application.port.in.ManageUserPreferencesUseCase;
+import io.github.hexagonal.weather.application.port.out.UserPreferencesRepository;
+import io.github.hexagonal.weather.model.UserPreferences;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Service for managing user preferences.
+ */
+@ApplicationScoped
+public class UserPreferencesService implements ManageUserPreferencesUseCase {
+
+    private final UserPreferencesRepository repository;
+
+    public UserPreferencesService(UserPreferencesRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public UserPreferences savePreferences(UserPreferences preferences) {
+        return repository.save(preferences);
+    }
+
+    @Override
+    public UserPreferences getPreferences(String userId) {
+        return repository.findByUserId(userId)
+                .orElse(new UserPreferences(userId));
+    }
+}

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -32,6 +32,10 @@
             <groupId>io.github.hexagonal</groupId>
             <artifactId>adapter-openmeteo</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.github.hexagonal</groupId>
+            <artifactId>adapter-preferences</artifactId>
+        </dependency>
 
         <!-- Quarkus extensions -->
         <dependency>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -28,6 +28,12 @@
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>
 
+        <!-- Jakarta Persistence for entity mapping -->
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+        </dependency>
+
         <!-- JUnit for testing -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/model/src/main/java/io/github/hexagonal/weather/model/Location.java
+++ b/model/src/main/java/io/github/hexagonal/weather/model/Location.java
@@ -1,5 +1,6 @@
 package io.github.hexagonal.weather.model;
 
+import jakarta.persistence.Embeddable;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -11,6 +12,7 @@ import jakarta.validation.constraints.NotBlank;
  * @param longitude Longitude coordinate (-180 to 180)
  * @param cityName  Optional city name for display purposes
  */
+@Embeddable
 public record Location(
     @Min(-90) @Max(90) double latitude,
     @Min(-180) @Max(180) double longitude,

--- a/model/src/main/java/io/github/hexagonal/weather/model/TemperatureUnit.java
+++ b/model/src/main/java/io/github/hexagonal/weather/model/TemperatureUnit.java
@@ -1,0 +1,16 @@
+package io.github.hexagonal.weather.model;
+
+/**
+ * Represents temperature unit preferences.
+ */
+public enum TemperatureUnit {
+    CELSIUS,
+    FAHRENHEIT;
+
+    public double convert(double celsius) {
+        return switch (this) {
+            case CELSIUS -> celsius;
+            case FAHRENHEIT -> (celsius * 9.0 / 5.0) + 32.0;
+        };
+    }
+}

--- a/model/src/main/java/io/github/hexagonal/weather/model/UserPreferences.java
+++ b/model/src/main/java/io/github/hexagonal/weather/model/UserPreferences.java
@@ -1,0 +1,24 @@
+package io.github.hexagonal.weather.model;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Represents user preferences for weather service personalization.
+ *
+ * @param userId User identifier
+ * @param temperatureUnit Preferred temperature unit (CELSIUS or FAHRENHEIT)
+ * @param defaultLocation Default location for quick weather access
+ * @param notificationsEnabled Whether to enable weather notifications
+ */
+public record UserPreferences(
+    @NotBlank String userId,
+    @NotNull TemperatureUnit temperatureUnit,
+    @Valid Location defaultLocation,
+    boolean notificationsEnabled
+) {
+    public UserPreferences(String userId) {
+        this(userId, TemperatureUnit.CELSIUS, null, false);
+    }
+}

--- a/model/src/main/java/io/github/hexagonal/weather/model/WeatherHistory.java
+++ b/model/src/main/java/io/github/hexagonal/weather/model/WeatherHistory.java
@@ -1,0 +1,87 @@
+package io.github.hexagonal.weather.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.Instant;
+
+/**
+ * Domain model representing historical weather data.
+ * Stores weather observations for a location at a specific point in time.
+ */
+@Entity
+@Table(name = "weather_history")
+public class WeatherHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Embedded
+    @Valid
+    @NotNull
+    private Location location;
+
+    @Column(name = "temperature_celsius")
+    private double temperature;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "weather_condition")
+    @NotNull
+    private WeatherCondition condition;
+
+    @Column(name = "observed_at")
+    @NotNull
+    private Instant timestamp;
+
+    @Column(name = "created_at")
+    private Instant createdAt;
+
+    // JPA requires no-arg constructor
+    protected WeatherHistory() {
+    }
+
+    public WeatherHistory(Location location, double temperature, WeatherCondition condition, Instant timestamp) {
+        this.location = location;
+        this.temperature = temperature;
+        this.condition = condition;
+        this.timestamp = timestamp;
+        this.createdAt = Instant.now();
+    }
+
+    // Factory method from Weather domain object
+    public static WeatherHistory fromWeather(Weather weather) {
+        return new WeatherHistory(
+            weather.location(),
+            weather.temperature(),
+            weather.condition(),
+            weather.timestamp()
+        );
+    }
+
+    // Getters for JPA
+    public Long getId() {
+        return id;
+    }
+
+    public Location getLocation() {
+        return location;
+    }
+
+    public double getTemperature() {
+        return temperature;
+    }
+
+    public WeatherCondition getCondition() {
+        return condition;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,11 @@
                 <artifactId>adapter-openmeteo</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.github.hexagonal</groupId>
+                <artifactId>adapter-preferences</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
             <!-- Lombok -->
             <dependency>


### PR DESCRIPTION
Implement user preferences functionality to allow users to customize their weather experience with the following capabilities:

- Save and retrieve user weather preferences
- Configure temperature unit preference (Celsius/Fahrenheit)
- Set default location for weather queries
- Enable/disable weather notifications

Technical implementation:
- New UserPreferences domain model
- ManageUserPreferencesUseCase port
- UserPreferencesService application service
- REST endpoints at /preferences
- In-memory repository for preference storage

+semver: minor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added REST API to manage user weather preferences: create/update and retrieve by user ID.
  * Preferences support temperature unit (Celsius/Fahrenheit), default location (latitude, longitude, optional city name), and notifications toggle.
  * Returns sensible defaults when no preferences exist for a user.
  * Responses use clear JSON fields (user_id, temperature_unit, default_location, notifications_enabled).
* Chores
  * Introduced an in-memory storage for preferences to enable immediate use without external databases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->