### PR TITLE
Add weather history tracking

### DIFF
--- a/model/pom.xml
+++ b/model/pom.xml
@@ -28,6 +28,12 @@
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>
 
+        <!-- Jakarta Persistence for entity mapping -->
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+        </dependency>
+
         <!-- JUnit for testing -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/model/src/main/java/io/github/hexagonal/weather/model/Location.java
+++ b/model/src/main/java/io/github/hexagonal/weather/model/Location.java
@@ -1,5 +1,6 @@
 package io.github.hexagonal.weather.model;
 
+import jakarta.persistence.Embeddable;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -11,6 +12,7 @@ import jakarta.validation.constraints.NotBlank;
  * @param longitude Longitude coordinate (-180 to 180)
  * @param cityName  Optional city name for display purposes
  */
+@Embeddable
 public record Location(
     @Min(-90) @Max(90) double latitude,
     @Min(-180) @Max(180) double longitude,

--- a/model/src/main/java/io/github/hexagonal/weather/model/WeatherHistory.java
+++ b/model/src/main/java/io/github/hexagonal/weather/model/WeatherHistory.java
@@ -1,0 +1,87 @@
+package io.github.hexagonal.weather.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.Instant;
+
+/**
+ * Domain model representing historical weather data.
+ * Stores weather observations for a location at a specific point in time.
+ */
+@Entity
+@Table(name = "weather_history")
+public class WeatherHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Embedded
+    @Valid
+    @NotNull
+    private Location location;
+
+    @Column(name = "temperature_celsius")
+    private double temperature;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "weather_condition")
+    @NotNull
+    private WeatherCondition condition;
+
+    @Column(name = "observed_at")
+    @NotNull
+    private Instant timestamp;
+
+    @Column(name = "created_at")
+    private Instant createdAt;
+
+    // JPA requires no-arg constructor
+    protected WeatherHistory() {
+    }
+
+    public WeatherHistory(Location location, double temperature, WeatherCondition condition, Instant timestamp) {
+        this.location = location;
+        this.temperature = temperature;
+        this.condition = condition;
+        this.timestamp = timestamp;
+        this.createdAt = Instant.now();
+    }
+
+    // Factory method from Weather domain object
+    public static WeatherHistory fromWeather(Weather weather) {
+        return new WeatherHistory(
+            weather.location(),
+            weather.temperature(),
+            weather.condition(),
+            weather.timestamp()
+        );
+    }
+
+    // Getters for JPA
+    public Long getId() {
+        return id;
+    }
+
+    public Location getLocation() {
+        return location;
+    }
+
+    public double getTemperature() {
+        return temperature;
+    }
+
+    public WeatherCondition getCondition() {
+        return condition;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a weather history tracking feature to store historical weather observations. This enables analysis of weather patterns over time and provides data for reporting.

## Changes

- Added `WeatherHistory` domain model to track past weather observations
- Enhanced `Location` model to support persistence
- Updated model module dependencies to include JPA support

## Technical Details

### New Domain Model
- `WeatherHistory` - Stores weather observations with location, temperature, condition, and timestamp
- Each record includes a creation timestamp for audit purposes
- Factory method `fromWeather()` to easily create history records from current weather

### Database Schema
- Table: `weather_history`
- Columns: id, location (embedded), temperature, condition, observed_at, created_at

## Testing

- Build passes successfully
- All existing tests remain green
- No breaking changes to existing functionality

## Next Steps

Future enhancements could include:
- REST endpoint to retrieve historical weather data
- Repository implementation for persistence
- Query capabilities for date ranges and locations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Weather history tracking: past observations are now recorded with location, temperature, condition, and timestamps.
  - One-click conversion from a current weather reading into a saved history entry.

- **Improvements**
  - Easier location creation with a two-value option (latitude and longitude), auto-filling the city name when unspecified.

- **Chores**
  - Added persistence support to store history records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->